### PR TITLE
fix dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "chai": "^4.1.2",
     "electron": "^1.8.2",
     "electron-mocha": "^5.0.0",
-    "fs-extra": "^5.0.0",
     "mocha": "^5.0.0",
     "standard": "^10.0.3",
     "trytryagain": "^1.2.0"
@@ -27,6 +26,7 @@
   },
   "dependencies": {
     "debug": "^3.1.0",
+    "fs-extra": "^5.0.0",
     "yargs": "^11.0.0"
   }
 }


### PR DESCRIPTION
move fs-extra from dev dependencies to dependencies
fixes this issue

```
$ yarn create hyperdom-app myApp
yarn create v1.3.2
[1/4] Resolving packages...
[2/4] Fetching packages...
[3/4] Linking dependencies...
[4/4] Building fresh packages...
success Installed "create-hyperdom-app@1.0.2" with binaries:
      - create-hyperdom-app
[#######################################################] 55/55module.js:538
    throw err;
    ^

Error: Cannot find module 'fs-extra'
    at Function.Module._resolveFilename (module.js:536:15)
    at Function.Module._load (module.js:466:25)
    at Module.require (module.js:579:17)
    at require (internal/module.js:11:18)
    at Object.<anonymous> (/home/derek/.config/yarn/global/node_modules/create-hyperdom-app/index.js:3:10)
    at Module._compile (module.js:635:30)
    at Object.Module._extensions..js (module.js:646:10)
    at Module.load (module.js:554:32)
    at tryModuleLoad (module.js:497:12)
    at Function.Module._load (module.js:489:3)
error Command failed.
Exit code: 1
```

The tests pass but I couldn't figure how to actually test the local package?
Seems like it will do the trick though.